### PR TITLE
Fix for community-app issue #148

### DIFF
--- a/src/components/TopNav/index.js
+++ b/src/components/TopNav/index.js
@@ -249,6 +249,46 @@ const TopNav = ({
     }
   }, [activeLevel1Id, activeLevel2Id, path])
 
+  const isLevel3ExactPath = (menuWithId_, path_) => {
+    let found = { exact: false }
+
+    // If haven't a path just return
+    if (!path_) return found
+
+    menuWithId_.forEach(level1 => {
+      level1.subMenu && level1.subMenu.forEach(level2 => {
+        level2.subMenu && level2.subMenu.forEach(level3 => {
+          if (level3.href && path_.indexOf(level3.href) > -1) {
+            if (found.exact) {
+              if (level3.href === path_) found = { exact: true }
+            } else {
+              found = { exact: path_.endsWith(level3.href) }
+            }
+          }
+        })
+      })
+      level1.secondaryMenu && level1.secondaryMenu.forEach(level3 => {
+        if (level3.href) {
+          // Check if path have parameters
+          const href = level3.href.indexOf('?') > -1 ? level3.href.split('?')[0] : level3.href
+          if (path_.indexOf(href) > -1) found = { exact: path_.endsWith(href) }
+        }
+      })
+    })
+    return found
+  }
+
+  useEffect(() => {
+    if (!path || !menuWithId) return
+    // check if current path is an exact matches with level3 href
+    const { exact } = isLevel3ExactPath(menuWithId, path)
+    if (!exact) {
+      setActiveLevel3Id(undefined)
+      setIconSelectPos(undefined)
+      setShowIconSelect(false)
+    }
+  }, [activeLevel3Id])
+
   const createHandleClickLevel3 = menuId => () => {
     setActiveLevel3Id(menuId)
     setIconSelectPos(menuId)


### PR DESCRIPTION
#148 

Deselect active level3 menu when current path is not the exact match to level3.href so the menu can be clickable again.

Case in point when in review opportunities page, user will be able to select All Challenge from the menu.